### PR TITLE
Archive extraction fails, if the archive includes a write-protected dir

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -25,7 +25,8 @@ func TestMkdirAll(t *testing.T) {
 	// Check that the directories were created with 0700 permissions
 	info, err := os.Stat(testPath)
 	assert.NoError(t, err, "Failed to stat directory")
-	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "Expected directory to have permissions 0700")
+
+	assert.Equal(t, uint32(os.FileMode(0700)), uint32(info.Mode().Perm()), "Expected directory to have permissions 0700")
 
 	// Step 2: Run MkdirAll which should change permissions to 0755
 	restore, err := mkdirAll(testPath)
@@ -34,14 +35,14 @@ func TestMkdirAll(t *testing.T) {
 	// Check that the permissions were changed to 0755
 	info, err = os.Stat(testPath)
 	assert.NoError(t, err, "Failed to stat directory after MkdirAll")
-	assert.Equal(t, os.FileMode(0755), info.Mode().Perm(), "Expected directory to have permissions 0755 after MkdirAll")
+	assert.Equal(t, uint32(os.FileMode(0755)), uint32(info.Mode().Perm()), "Expected directory to have permissions 0755 after MkdirAll")
 
 	// Step 3: Simulate changing the permissions to 0700 (simulating a permission modification)
 	err = os.Chmod(testPath, 0700)
 	assert.NoError(t, err, "Failed to change directory permissions to 0700")
 	info, err = os.Stat(testPath)
 	assert.NoError(t, err, "Failed to stat directory after permission change")
-	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "Expected directory to have permissions 0700 after permission change")
+	assert.Equal(t, uint32(os.FileMode(0700)), uint32(info.Mode().Perm()), "Expected directory to have permissions 0700 after permission change")
 
 	// Step 4: Restore the original permissions using the deferred restore function
 	err = restore()
@@ -50,7 +51,7 @@ func TestMkdirAll(t *testing.T) {
 	// Verify that the original permissions (0700) were restored
 	info, err = os.Stat(testPath)
 	assert.NoError(t, err, "Failed to stat directory after restoration")
-	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "Expected directory to have restored permissions 0755")
+	assert.Equal(t, uint32(os.FileMode(0700)), uint32(info.Mode().Perm()), "Expected directory to have restored permissions 0755")
 }
 
 func TestWithin(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,13 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/nwaples/rardecode v1.1.3
 	github.com/pierrec/lz4/v4 v4.1.21
+	github.com/stretchr/testify v1.9.0
 	github.com/ulikunitz/xz v0.5.12
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
@@ -15,8 +17,16 @@ github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9l
 github.com/nwaples/rardecode v1.1.3/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This is an attempt at fixing https://github.com/jfrog/jfrog-cli/issues/2652 where the extraction of an archive fails, when the archive includes a directory without write permissions.
In that scenario, the extraction fails when it tries to create the new file inside the directory, beucase that directory has no write permissions.
To try and overcome this, the extraction process has been improved as part of this PR as follows:
A new `mkdirAll` function has been added, replacing the default `od.MkdirAll` function. The new function temporarily sets 0755 permissions for all the directories, and then returns a restore function to revert the permission changes, after the file was created.

Fix https://github.com/jfrog/jfrog-cli/issues/2652